### PR TITLE
Add PyInstaller build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,87 @@
+name: Build
+
+on: workflow_dispatch
+
+env:
+  pyinstaller-version: "4.0"
+  name: modimporter
+
+jobs:
+  archive-and-upload-python-artifacts:
+    name: Archive and upload Python artifacts
+    runs-on: ubuntu-latest
+    env:
+      artifacts-python: modimporter-python
+      license: LICENSE
+      readme: README.md
+      sjson: sjson
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: ${{ github.sha }}
+          submodules: true
+
+      - name: Remove `.git` folder from submodules
+        run: |
+          rm -r ${{ env.sjson }}/.git
+
+      - name: Upload artifacts to workflow
+        uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
+        with:
+          name: ${{ env.artifacts-python }}
+          path: |
+            ${{ env.name }}.py
+            ${{ env.sjson }}
+            ${{ env.license }}
+            ${{ env.readme }}
+          retention-days: 1
+
+  build-and-upload-binaries:
+    name: Build and upload binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        include:
+          - os: windows-latest
+            pip-cache-path: ~\AppData\Local\pip\Cache
+            artifacts: modimporter-windows
+          - os: macos-latest
+            pip-cache-path: ~/Library/Caches/pip
+            artifacts: modimporter-macos
+          - os: ubuntu-latest
+            pip-cache-path: ~/.cache/pip
+            artifacts: modimporter-linux
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: ${{ github.sha }}
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6
+        with:
+          python-version: 3.9
+
+      - name: Retrieve pip dependencies from cache
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        with:
+          path: |
+            ${{ env.pythonLocation }}\lib\site-packages
+            ${{ matrix.pip-cache-path }}
+          key: ${{ runner.os }}-pip-cache-${{ env.pyinstaller-version }}
+
+      - name: Install pip dependencies
+        run: python -m pip install pyinstaller==${{ env.pyinstaller-version }}
+
+      - name: Build binaries with PyInstaller
+        run: python -m PyInstaller --onefile ${{ env.name }}.py --name ${{ env.name }}
+
+      - name: Upload artifacts to workflow
+        uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
+        with:
+          name: ${{ matrix.artifacts }}
+          path: dist/*
+          retention-days: 1

--- a/.gitignores
+++ b/.gitignores
@@ -1,0 +1,5 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+

--- a/.gitignores
+++ b/.gitignores
@@ -3,3 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# PyInstaller
+build/
+dist/
+*.spec

--- a/README.md
+++ b/README.md
@@ -2,3 +2,29 @@
 For SuperGiantGames's games (To be replaced by SGGMI)
 
 https://www.nexusmods.com/hades/mods/26
+
+## Development
+
+Binaries can be built from GitHub Actions runners using the build workflow
+available [here](https://github.com/SGG-Modding/sgg-mod-modimporter/actions/workflows/build.yaml).
+
+To build binaries locally:
+
+- Install [PyInstaller](https://pypi.org/project/pyinstaller/):
+
+```bat
+python -m pip install pyinstaller==4.0
+```
+
+> Note that we use version 4.0 instead of the latest version to avoid getting
+flagged by too many antivirus solutions due to PyInstaller's
+pre-compiled bootloader. Older versions are less susceptible to this as AV
+solutions had more time to properly recognize and whitelist them, in particular
+from Microsoft antivirus (which is the single most important one not to get
+flagged by).
+
+- Build binaries:
+
+```bat
+python -m PyInstaller --onefile modimporter.py --name modimporter
+```


### PR DESCRIPTION
Proposal to add a GitHub Actions workflow that uses PyInstaller to build standalone binaries of `modimporter`, removing the need for end users to install Python in order to import Hades mods. The workflow is triggered on-demand manually from the GitHub Actions tab:
![image](https://user-images.githubusercontent.com/4659919/133910446-bf841763-21ca-4a17-b462-26f764243553.png)

This workflow is a simplified version of the workflow I have been using for Hephaistos (see [here](https://github.com/nbusseneau/hephaistos/blob/main/.github/workflows/build-release.yaml)) with the GitHub release management part stripped out.

Here is an example of the result of running the workflow from this PR: https://github.com/nbusseneau/sgg-mod-modimporter/actions/runs/1249496372 (note: the artifacts uploaded to the workflow are only kept for 1 day, as the purpose of the workflow is "just" to automate the build part, but not hold the artifacts forever: to that end they should be moved somewhere else e.g. on NexusMods or GitHub releases).

Note that we use version 4.0 of PyInstaller instead of the latest one to avoid getting flagged by too many antivirus solutions due to PyInstaller's pre-compiled bootloader. Older versions are less susceptible to this as AV solutions had more time to properly recognize and whitelist them, in particular from Microsoft antivirus (which is the single most important one not to get flagged by).

As a comparison, here are the outputs of a VirusTotal analysis of `modimporter.exe` built using:
- [PyInstaller 4.0](https://www.virustotal.com/gui/file/18a955c2507a7366498e872d1bb165ac50be3a2d0f0b82ce9886b9f3f1abd15d)
- [Latest PyInstaller (4.5.1 at time of writing)](https://www.virustotal.com/gui/file/b69c71b0ca8b19c36d7e2b0d766f3bc53f334edeb11b3fa33a31dbc4fd796bb7)